### PR TITLE
Cleanup and fixes for using latest versions of JeeLabs libraries

### DIFF
--- a/Guide/d_PacketBuffer/d_PacketBuffer.ino
+++ b/Guide/d_PacketBuffer/d_PacketBuffer.ino
@@ -21,7 +21,7 @@ public:
     byte length() { return fill; }
     void reset()
     { 
-      memset(buf,NULL,sizeof(buf));
+      memset(buf,0,sizeof(buf));
       fill = 0; 
     }
     virtual size_t write (uint8_t ch)

--- a/Guide/e_BasicMultiNodeWebClient/e_BasicMultiNodeWebClient.ino
+++ b/Guide/e_BasicMultiNodeWebClient/e_BasicMultiNodeWebClient.ino
@@ -25,7 +25,7 @@ public:
     byte length() { return fill; }
     void reset()
     { 
-      memset(buf,NULL,sizeof(buf));
+      memset(buf,0,sizeof(buf));
       fill = 0; 
     }
     virtual size_t write (uint8_t ch)
@@ -43,14 +43,14 @@ static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 
 byte Ethernet::buffer[700];
 
-char website[] PROGMEM = "emoncms.org";
+const char website[] PROGMEM = "emoncms.org";
 
 void setup () 
 {
   Serial.begin(9600);
   Serial.println("05 - Basic MultiNode Web Client");
 
-  if (ether.begin(sizeof Ethernet::buffer, mymac) == 0) 
+  if (ether.begin(sizeof Ethernet::buffer, mymac, 8) == 0) 
     Serial.println( "Failed to access Ethernet controller");
   if (!ether.dhcpSetup())
     Serial.println("DHCP failed");

--- a/Guide/f_ReceivingReply/decode_reply.ino
+++ b/Guide/f_ReceivingReply/decode_reply.ino
@@ -1,6 +1,6 @@
 int get_reply_data(word off)
 {
-  memset(line_buf,NULL,sizeof(line_buf));
+  memset(line_buf,0,sizeof(line_buf));
   if (off != 0)
   {
     uint16_t pos = off;

--- a/Guide/f_ReceivingReply/f_ReceivingReply.ino
+++ b/Guide/f_ReceivingReply/f_ReceivingReply.ino
@@ -28,7 +28,7 @@ static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 byte Ethernet::buffer[700];
 unsigned long timer;
 
-char website[] PROGMEM = "emoncms.org";
+const char website[] PROGMEM = "emoncms.org";
 
 // This is the char array that holds the reply data
 char line_buf[50];
@@ -38,7 +38,7 @@ void setup ()
   Serial.begin(9600);
   Serial.println("06 - Receiving a reply");
 
-  if (ether.begin(sizeof Ethernet::buffer, mymac) == 0) 
+  if (ether.begin(sizeof Ethernet::buffer, mymac, 8) == 0) 
     Serial.println( "Failed to access Ethernet controller");
   if (!ether.dhcpSetup())
     Serial.println("DHCP failed");

--- a/Guide/g_FetchEmoncmsFeedValue/decode_reply.ino
+++ b/Guide/g_FetchEmoncmsFeedValue/decode_reply.ino
@@ -1,6 +1,6 @@
 int get_reply_data(word off)
 {
-  memset(line_buf,NULL,sizeof(line_buf));
+  memset(line_buf,0,sizeof(line_buf));
   if (off != 0)
   {
     uint16_t pos = off;

--- a/Guide/g_FetchEmoncmsFeedValue/g_FetchEmoncmsFeedValue.ino
+++ b/Guide/g_FetchEmoncmsFeedValue/g_FetchEmoncmsFeedValue.ino
@@ -18,7 +18,7 @@ static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 byte Ethernet::buffer[700];
 unsigned long timer;
 
-char website[] PROGMEM = "emoncms.org";
+const char website[] PROGMEM = "emoncms.org";
 
 // This is the char array that holds the reply data
 char line_buf[50];
@@ -34,7 +34,7 @@ void setup ()
   pinMode(redLED, OUTPUT); digitalWrite(redLED,HIGH);            
   pinMode(greenLED, OUTPUT); digitalWrite(greenLED,HIGH); 
 
-  if (ether.begin(sizeof Ethernet::buffer, mymac) == 0) 
+  if (ether.begin(sizeof Ethernet::buffer, mymac,8) == 0) 
     Serial.println( "Failed to access Ethernet controller");
   if (!ether.dhcpSetup())
     Serial.println("DHCP failed");

--- a/NanodeRF_Cosm/NanodeRF_Cosm.ino
+++ b/NanodeRF_Cosm/NanodeRF_Cosm.ino
@@ -59,7 +59,7 @@ public:
     byte length() { return fill; }
     void reset()
     { 
-      memset(buf,NULL,sizeof(buf));
+      memset(buf,0,sizeof(buf));
       fill = 0; 
     }
     virtual size_t write (uint8_t ch)
@@ -83,7 +83,7 @@ byte Ethernet::buffer[700];
 static uint32_t timer;
 
 //Domain name of remote webserver - leave blank if posting to IP address 
-char website[] PROGMEM = "api.cosm.com";
+const char website[] PROGMEM = "api.cosm.com";
 
 const int redLED = 6;                     // NanodeRF RED indicator LED
 //const int redLED = 17;  		  // Open Kontrol Gateway LED indicator
@@ -117,7 +117,6 @@ void setup () {
   Serial.println("\n[webClient]");
 
   //if (ether.begin(sizeof Ethernet::buffer, mymac, 10) == 0) {	//for use with Open Kontrol Gateway 
-  if (ether.begin(sizeof Ethernet::buffer, mymac) == 0) {	//for use with NanodeRF
   if (ether.begin(sizeof Ethernet::buffer, mymac) == 0) {
     Serial.println( "Failed to access Ethernet controller");
     ethernet_error = 1;  
@@ -140,9 +139,9 @@ void setup () {
  
   #ifdef UNO
   wdt_enable(WDTO_8S); 
-  #endif;
+  #endif
 }
-  }
+
 
 //**********************************************************************************************************************
 // LOOP
@@ -258,13 +257,13 @@ static void my_callback (byte status, word off, word len) {
     // We just search for the characters and hope they are in the right place
     char val[1];
     val[0] = line_buf[23]; val[1] = line_buf[24];
-    int hour = atoi(val);
+    char hour = atoi(val);
     val[0] = line_buf[26]; val[1] = line_buf[27];
-    int minute = atoi(val);
+    char minute = atoi(val);
     val[0] = line_buf[29]; val[1] = line_buf[30];
-    int second = atoi(val);
+    char second = atoi(val);
     val[0] = line_buf[11]; val[1] = line_buf[12];
-    int day = atoi(val);
+    char day = atoi(val);
     
     // Don't send all zeros, happens when server failes to returns reponce to avoide GLCD getting mistakenly set to midnight
     if (hour>0 || minute>0 || second>0) 

--- a/NanodeRF_Cosm/decode_reply.ino
+++ b/NanodeRF_Cosm/decode_reply.ino
@@ -1,6 +1,6 @@
 int get_header_line(int line,word off)
 {
-  memset(line_buf,NULL,sizeof(line_buf));
+  memset(line_buf,0,sizeof(line_buf));
   if (off != 0)
   {
     uint16_t pos = off;
@@ -27,7 +27,7 @@ int get_header_line(int line,word off)
 
 int get_reply_data(word off)
 {
-  memset(line_buf,NULL,sizeof(line_buf));
+  memset(line_buf,0,sizeof(line_buf));
   if (off != 0)
   {
     uint16_t pos = off;

--- a/NanodeRF_Cosm/dhcp_dns.ino
+++ b/NanodeRF_Cosm/dhcp_dns.ino
@@ -50,7 +50,7 @@ void dhcp_dns()
     
     #ifdef UNO
     wdt_enable(WDTO_8S);
-    #endif;
+    #endif
     
     Serial.print("DNS status: ");             // print
     Serial.println(dns_status);               // dns status

--- a/NanodeRF_Power_RTCrelay_GLCDtemp/NanodeRF_Power_RTCrelay_GLCDtemp.ino
+++ b/NanodeRF_Power_RTCrelay_GLCDtemp/NanodeRF_Power_RTCrelay_GLCDtemp.ino
@@ -58,7 +58,7 @@ public:
     byte length() { return fill; }
     void reset()
     { 
-      memset(buf,NULL,sizeof(buf));
+      memset(buf,0,sizeof(buf));
       fill = 0; 
     }
     virtual size_t write (uint8_t ch)
@@ -79,7 +79,7 @@ PacketBuffer str;
 static byte mymac[] = { 0x42,0x31,0x42,0x21,0x30,0x31 };
 
 // 1) Set this to the domain name of your hosted emoncms - leave blank if posting to IP address 
-char website[] PROGMEM = "emoncms.org";
+const char website[] PROGMEM = "emoncms.org";
 
 // or if your posting to a static IP server:
 static byte hisip[] = { 192,168,1,10 };
@@ -130,7 +130,7 @@ void setup () {
   Serial.println("\n[webClient]");
 
   //if (ether.begin(sizeof Ethernet::buffer, mymac, 10) == 0) {	//for use with Open Kontrol Gateway 
-  if (ether.begin(sizeof Ethernet::buffer, mymac) == 0) {	//for use with NanodeRF
+  if (ether.begin(sizeof Ethernet::buffer, mymac,8) == 0) {	//for use with NanodeRF
     Serial.println( "Failed to access Ethernet controller");
     ethernet_error = 1;  
   }
@@ -152,7 +152,7 @@ void setup () {
  
   #ifdef UNO
   wdt_enable(WDTO_8S); 
-  #endif;
+  #endif
 }
 
 //**********************************************************************************************************************
@@ -284,11 +284,11 @@ static void my_callback (byte status, word off, word len) {
     Serial.println(line_buf);
     
     char tmp[] = {line_buf[1],line_buf[2],0};
-    byte hour = atoi(tmp);
+    char hour = atoi(tmp);
     tmp[0] = line_buf[4]; tmp[1] = line_buf[5];
-    byte minute = atoi(tmp);
+    char minute = atoi(tmp);
     tmp[0] = line_buf[7]; tmp[1] = line_buf[8];
-    byte second = atoi(tmp);
+    char second = atoi(tmp);
 
     if (hour>0 || minute>0 || second>0) 
     {  

--- a/NanodeRF_Power_RTCrelay_GLCDtemp/decode_reply.ino
+++ b/NanodeRF_Power_RTCrelay_GLCDtemp/decode_reply.ino
@@ -1,6 +1,6 @@
 int get_header_line(int line,word off)
 {
-  memset(line_buf,NULL,sizeof(line_buf));
+  memset(line_buf,0,sizeof(line_buf));
   if (off != 0)
   {
     uint16_t pos = off;
@@ -27,7 +27,7 @@ int get_header_line(int line,word off)
 
 int get_reply_data(word off)
 {
-  memset(line_buf,NULL,sizeof(line_buf));
+  memset(line_buf,0,sizeof(line_buf));
   if (off != 0)
   {
     uint16_t pos = off;

--- a/NanodeRF_Power_RTCrelay_GLCDtemp/dhcp_dns.ino
+++ b/NanodeRF_Power_RTCrelay_GLCDtemp/dhcp_dns.ino
@@ -54,7 +54,7 @@ void dhcp_dns()
     
     #ifdef UNO
     wdt_enable(WDTO_8S);
-    #endif;
+    #endif
     
     Serial.print("DNS status: ");             // print
     Serial.println(dns_status);               // dns status

--- a/NanodeRF_Test/NanodeRF_Test.ino
+++ b/NanodeRF_Test/NanodeRF_Test.ino
@@ -13,7 +13,7 @@ const int redLED=6;
 // ethernet interface mac address
 static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 // remote website name
-char website[] PROGMEM = "google.com";
+const char website[] PROGMEM = "google.com";
 
 byte Ethernet::buffer[700];
 static long timer;
@@ -46,7 +46,7 @@ digitalWrite(redLED, HIGH);
   Serial.begin(9600);
   Serial.println("\n[getDHCPandDNS]");
   
-  if (ether.begin(sizeof Ethernet::buffer, mymac) == 0) 
+  if (ether.begin(sizeof Ethernet::buffer, mymac, 8) == 0) 
   {
     Serial.println( "Failed to access Ethernet controller");
     digitalWrite(redLED, LOW); 

--- a/NanodeRF_multinode/NanodeRF_multinode.ino
+++ b/NanodeRF_multinode/NanodeRF_multinode.ino
@@ -46,7 +46,7 @@ public:
     byte length() { return fill; }
     void reset()
     { 
-      memset(buf,NULL,sizeof(buf));
+      memset(buf,0,sizeof(buf));
       fill = 0; 
     }
     virtual size_t write (uint8_t ch)
@@ -68,7 +68,7 @@ PacketBuffer str;
 static byte mymac[] = { 0x42,0x31,0x42,0x21,0x30,0x31 };
 
 // 1) Set this to the domain name of your hosted emoncms - leave blank if posting to IP address 
-char website[] PROGMEM = "emoncms.org";
+const char website[] PROGMEM = "emoncms.org";
 
 // or if your posting to a static IP server:
 static byte hisip[] = { 192,168,1,10 };
@@ -118,7 +118,7 @@ void setup () {
   Serial.println("\n[webClient]");
 
   //if (ether.begin(sizeof Ethernet::buffer, mymac, 10) == 0) {	//for use with Open Kontrol Gateway 
-  if (ether.begin(sizeof Ethernet::buffer, mymac) == 0) {	//for use with NanodeRF
+  if (ether.begin(sizeof Ethernet::buffer, mymac,8) == 0) {	//for use with NanodeRF
     Serial.println( "Failed to access Ethernet controller");
     ethernet_error = 1;  
   }
@@ -140,7 +140,7 @@ void setup () {
  
   #ifdef UNO
   wdt_enable(WDTO_8S); 
-  #endif;
+  #endif
 }
 
 //**********************************************************************************************************************
@@ -247,11 +247,11 @@ static void my_callback (byte status, word off, word len) {
     Serial.println(line_buf);
     
     char tmp[] = {line_buf[1],line_buf[2],0};
-    byte hour = atoi(tmp);
+    char hour = atoi(tmp);
     tmp[0] = line_buf[4]; tmp[1] = line_buf[5];
-    byte minute = atoi(tmp);
+    char minute = atoi(tmp);
     tmp[0] = line_buf[7]; tmp[1] = line_buf[8];
-    byte second = atoi(tmp);
+    char second = atoi(tmp);
 
     if (hour>0 || minute>0 || second>0) 
     {  

--- a/NanodeRF_multinode/decode_reply.ino
+++ b/NanodeRF_multinode/decode_reply.ino
@@ -1,6 +1,6 @@
 int get_header_line(int line,word off)
 {
-  memset(line_buf,NULL,sizeof(line_buf));
+  memset(line_buf,0L,sizeof(line_buf));
   if (off != 0)
   {
     uint16_t pos = off;
@@ -27,7 +27,7 @@ int get_header_line(int line,word off)
 
 int get_reply_data(word off)
 {
-  memset(line_buf,NULL,sizeof(line_buf));
+  memset(line_buf,0,sizeof(line_buf));
   if (off != 0)
   {
     uint16_t pos = off;

--- a/NanodeRF_multinode/dhcp_dns.ino
+++ b/NanodeRF_multinode/dhcp_dns.ino
@@ -54,7 +54,7 @@ void dhcp_dns()
     
     #ifdef UNO
     wdt_enable(WDTO_8S);
-    #endif;
+    #endif
     
     Serial.print("DNS status: ");             // print
     Serial.println(dns_status);               // dns status

--- a/NanodeRF_multinode_bulksend/NanodeRF_multinode_bulksend.ino
+++ b/NanodeRF_multinode_bulksend/NanodeRF_multinode_bulksend.ino
@@ -47,7 +47,7 @@ public:
     byte length() { return fill; }
     void reset()
     { 
-      memset(buf,NULL,sizeof(buf));
+      memset(buf,0,sizeof(buf));
       fill = 0; 
     }
     virtual size_t write (uint8_t ch)
@@ -67,7 +67,7 @@ PacketBuffer str;
 static byte mymac[] = { 0x42,0x31,0x42,0x21,0x30,0x31 };
 
 // 1) Set this to the domain name of your hosted emoncms - leave blank if posting to IP address 
-char website[] PROGMEM = "emoncms.org";
+const char website[] PROGMEM = "emoncms.org";
 
 //IP address of remote sever, only needed when posting to a server that has not got a dns domain name (staticIP e.g local server) 
 byte Ethernet::buffer[700];
@@ -88,7 +88,7 @@ void setup () {
   Serial.println("NanodeRF_multinode_bulksend");
 
   //if (ether.begin(sizeof Ethernet::buffer, mymac, 10) == 0) {	//for use with Open Kontrol Gateway 
-  if (ether.begin(sizeof Ethernet::buffer, mymac) == 0) {	//for use with NanodeRF
+  if (ether.begin(sizeof Ethernet::buffer, mymac, 8) == 0) {	//for use with NanodeRF
     Serial.println( "Failed to access Ethernet controller");
   }
   
@@ -114,7 +114,7 @@ void setup () {
 
   #ifdef UNO
   wdt_enable(WDTO_8S); 
-  #endif;
+  #endif
   
   ethernet_requests = 0;
   

--- a/NanodeRF_multinode_bulksend/decode_reply.ino
+++ b/NanodeRF_multinode_bulksend/decode_reply.ino
@@ -1,6 +1,6 @@
 int get_reply_data(word off)
 {
-  memset(line_buf,NULL,sizeof(line_buf));
+  memset(line_buf,0,sizeof(line_buf));
   if (off != 0)
   {
     uint16_t pos = off;

--- a/NanodeRF_multinode_static_IP/NanodeRF_multinode_static_IP.ino
+++ b/NanodeRF_multinode_static_IP/NanodeRF_multinode_static_IP.ino
@@ -46,7 +46,7 @@ public:
     byte length() { return fill; }
     void reset()
     { 
-      memset(buf,NULL,sizeof(buf));
+      memset(buf,0,sizeof(buf));
       fill = 0; 
     }
     virtual size_t write (uint8_t ch)
@@ -68,7 +68,7 @@ PacketBuffer str;
 static byte mymac[] = { 0x42,0x31,0x42,0x21,0x30,0x31 };
 
 // 1) Set this to the domain name of your hosted emoncms - leave blank if posting to IP address 
-char website[] PROGMEM = "";
+const char website[] PROGMEM = "";
 
 // or if your posting to a static IP server, change to true if you would like the sketch to post to static IP (not sure if this is working..)
 boolean use_hisip = true;  
@@ -122,7 +122,7 @@ void setup () {
   Serial.println("\n[webClient]");
 
   //if (ether.begin(sizeof Ethernet::buffer, mymac, 10) == 0) {	//for use with Open Kontrol Gateway 
-  if (ether.begin(sizeof Ethernet::buffer, mymac) == 0) {	//for use with NanodeRF
+  if (ether.begin(sizeof Ethernet::buffer, mymac,8) == 0) {	//for use with NanodeRF
     Serial.println( "Failed to access Ethernet controller");
     ethernet_error = 1;  
   }
@@ -150,7 +150,7 @@ void setup () {
  
   #ifdef UNO
   wdt_enable(WDTO_8S); 
-  #endif;
+  #endif
 }
 
 //**********************************************************************************************************************
@@ -258,11 +258,11 @@ static void my_callback (byte status, word off, word len) {
     Serial.println(line_buf);
     
     char tmp[] = {line_buf[1],line_buf[2],0};
-    byte hour = atoi(tmp);
+    char hour = atoi(tmp);
     tmp[0] = line_buf[4]; tmp[1] = line_buf[5];
-    byte minute = atoi(tmp);
+    char minute = atoi(tmp);
     tmp[0] = line_buf[7]; tmp[1] = line_buf[8];
-    byte second = atoi(tmp);
+    char second = atoi(tmp);
 
     if (hour>0 || minute>0 || second>0) 
     {  

--- a/NanodeRF_multinode_static_IP/decode_reply.ino
+++ b/NanodeRF_multinode_static_IP/decode_reply.ino
@@ -1,6 +1,6 @@
 int get_header_line(int line,word off)
 {
-  memset(line_buf,NULL,sizeof(line_buf));
+  memset(line_buf,0,sizeof(line_buf));
   if (off != 0)
   {
     uint16_t pos = off;
@@ -27,7 +27,7 @@ int get_header_line(int line,word off)
 
 int get_reply_data(word off)
 {
-  memset(line_buf,NULL,sizeof(line_buf));
+  memset(line_buf,0,sizeof(line_buf));
   if (off != 0)
   {
     uint16_t pos = off;

--- a/NanodeRF_multinode_static_IP/dhcp_dns.ino
+++ b/NanodeRF_multinode_static_IP/dhcp_dns.ino
@@ -54,7 +54,7 @@ void dhcp_dns()
     
     #ifdef UNO
     wdt_enable(WDTO_8S);
-    #endif;
+    #endif
     
     Serial.print("DNS status: ");             // print
     Serial.println(dns_status);               // dns status


### PR DESCRIPTION
This makes the allows the NanodeRF firmware to be built using the latest jeelibs libraries. It fixes a small number of compilation errors and cleans up a lot of warnings. More importantly if fixes the at fact that the new jeelib libraries the SPI the default chip select port in Ethercard.begin is DIG10 not DIG8 as required by the NanodeRX board.